### PR TITLE
Actioncable using dbc.net

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,4 +6,4 @@ test:
 
 production:
   adapter: redis
-  url: redis://localhost:6379/1
+  url: redis://redistogo:c5fadba109de6d3ea6d42d1ec11ba817@crestfish.redistogo.com:10763/

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,9 +2,9 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
   
   # actioncable setting for deployment to Heroku, default action is set to localhost
-  config.web_socket_server_url = "wss://safewalk-dbc.herokuapp.com/cable" 
+  config.web_socket_server_url = "wss://www.safewalk-dbc.net/cable" 
   config.action_cable.allowed_request_origins = ["http://www.safewalk-dbc.net"]
-    config.action_cable.allowed_request_origins = ["https://safewalk-dbc.herokuapp.com"]
+    # config.action_cable.allowed_request_origins = ["https://safewalk-dbc.herokuapp.com"]
 
   
   # Code is not reloaded between requests.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -4,8 +4,6 @@ Rails.application.configure do
   # actioncable setting for deployment to Heroku, default action is set to localhost
   config.web_socket_server_url = "wss://www.safewalk-dbc.net/cable" 
   config.action_cable.allowed_request_origins = ["http://www.safewalk-dbc.net"]
-    # config.action_cable.allowed_request_origins = ["https://safewalk-dbc.herokuapp.com"]
-
   
   # Code is not reloaded between requests.
   config.cache_classes = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,8 +2,8 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
   
   # actioncable setting for deployment to Heroku, default action is set to localhost
-  config.web_socket_server_url = "wss://safewalk-dbc.net/cable" 
-  config.action_cable.allowed_request_origins = ['http://www.safewalk-dbc.net/']
+  config.web_socket_server_url = "wss://safewalk-dbc.herokuapp.com/cable" 
+  config.action_cable.allowed_request_origins = ['https://safewalk-dbc.herokuapp.com/']
 
   
   # Code is not reloaded between requests.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,11 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+  
+  # actioncable setting for deployment to Heroku, default action is set to localhost
+  config.web_socket_server_url = "wss://safewalk-dbc.net/cable" 
+  config.action_cable.allowed_request_origins = ['http://www.safewalk-dbc.net/']
 
+  
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -4,6 +4,7 @@ Rails.application.configure do
   # actioncable setting for deployment to Heroku, default action is set to localhost
   config.web_socket_server_url = "wss://safewalk-dbc.herokuapp.com/cable" 
   config.action_cable.allowed_request_origins = ["http://www.safewalk-dbc.net"]
+    config.action_cable.allowed_request_origins = ["https://safewalk-dbc.herokuapp.com"]
 
   
   # Code is not reloaded between requests.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,7 +3,7 @@ Rails.application.configure do
   
   # actioncable setting for deployment to Heroku, default action is set to localhost
   config.web_socket_server_url = "wss://safewalk-dbc.herokuapp.com/cable" 
-  config.action_cable.allowed_request_origins = ['https://safewalk-dbc.herokuapp.com/']
+  config.action_cable.allowed_request_origins = ["http://www.safewalk-dbc.net"]
 
   
   # Code is not reloaded between requests.


### PR DESCRIPTION
- 404 actioncable error for chats.... 
- defaults to local host 127.0.0.1 when setting up actioncable, create redis URI on heroku, add to cable.yaml file 
- add redirected live site "http://www.safewalk-dbc.net" url to config...url and allowed origins into environment file